### PR TITLE
Don't detect 'darwin' as 'win'dows

### DIFF
--- a/ChromeController/transport.py
+++ b/ChromeController/transport.py
@@ -21,7 +21,7 @@ import subprocess
 import distutils.spawn
 from . import cr_exceptions
 
-if 'win' in sys.platform:
+if sys.platform == 'win32':
 	import win32con
 	import win32api
 
@@ -149,7 +149,7 @@ class ChromeExecutionManager():
 		# We need a separate process group on windows,
 		# to make ctrl+c work properly.
 		creationflags = 0
-		if 'win' in sys.platform:
+		if sys.platform == 'win32':
 			creationflags |= subprocess.CREATE_NEW_PROCESS_GROUP
 
 		preexec_fn = None
@@ -269,7 +269,7 @@ class ChromeExecutionManager():
 		'''
 		if self.cr_proc:
 			try:
-				if 'win' in sys.platform:
+				if sys.platform == 'win32':
 					self.__close_internal_windows()
 				else:
 					self.__close_internal_linux()


### PR DESCRIPTION
I'm trying to get this project working on macOS, which identifies in `sys.platform` as `darwin`. This causes confusion with the current `'win' in sys.platform`-check, causing the code to think macOS is Windows...

I don't have much experience in platform-detection, but based on [the examples in the documentation](https://docs.python.org/3/library/sys.html#sys.platform), this patch should do it.