### PR TITLE
Prevent endless loop in forever get_rendered_page_source function

### DIFF
--- a/ChromeController/manager.py
+++ b/ChromeController/manager.py
@@ -967,6 +967,7 @@ class ChromeRemoteDebugInterface(ChromeRemoteDebugInterface_base):
 			while 1:
 				if time.time() - start_time > max_wait_timeout:
 					self.log.debug("Page was not idle after waiting %s seconds. Giving up and extracting content now.", max_wait_timeout)
+					break
 				self.transport.recv_filtered(
 						filter_funcs.wait_for_methods(target_events),
 						tab_key = self.tab_id,


### PR DESCRIPTION
Prevent endless loop that blocks forever get_rendered_page_source function for pages that endlessly changes slides and url in address bar (i.e. www.zibettoespresso.com)