### PR TITLE
Check if process is dead after spawn

### DIFF
--- a/ChromeController/transport.py
+++ b/ChromeController/transport.py
@@ -167,6 +167,7 @@ class ChromeExecutionManager():
 
 		self.log.debug("Spawned process: %s, PID: %s", self.cr_proc, self.cr_proc.pid)
 		for x in range(100):
+			self._check_process_dead()
 			try:
 				self.tablist = self.fetch_tablist()
 


### PR DESCRIPTION
This can happen if the process exits prematurely for some external reason.
In my case, I'm using ChromeController for a Steam game running on Electron, which exits immediately if Steam isn't running.