### PR TITLE
disable chrome output redirection

### DIFF
--- a/ChromeController/transport.py
+++ b/ChromeController/transport.py
@@ -176,9 +176,6 @@ class ChromeExecutionManager():
 			preexec_fn = exit_handler.on_parent_exit('SIGTERM')
 
 		self.cr_proc = subprocess.Popen(argv,
-										stdin         = open(os.path.devnull, "r"),
-										stdout        = subprocess.PIPE,
-										stderr        = subprocess.PIPE,
 										creationflags = creationflags,
 										preexec_fn    = preexec_fn,
 									)


### PR DESCRIPTION
Disable output redirection can make process run in totally background, without any console window on windows.

Refer https://github.com/fake-name/ChromeController/issues/18